### PR TITLE
Renommage "repo" en "dépôt" (issue #68)

### DIFF
--- a/HELP.MD
+++ b/HELP.MD
@@ -32,7 +32,7 @@ Pour le moment, [quelques modérateurs autoproclamés](https://github.com/sveinb
 
 #### 1.1.2. Avec un fork
 
-Relativement complexe pour un non informaticien (notamment pour s'assurer que son **fork** est synchro avec le repo original. [Il existe des manières de le faire directement sur GitHub.com](http://stackoverflow.com/a/23853061/488666) mais c'est relativement lourd tout ça).
+Relativement complexe pour un non informaticien (notamment pour s'assurer que son **fork** est synchro avec le [dépôt](THE_APP.MD#I.7.a) original. [Il existe des manières de le faire directement sur GitHub.com](http://stackoverflow.com/a/23853061/488666) mais c'est relativement lourd tout ça).
 
 [Guide officiel GitHub.com (anglais)](https://guides.github.com/activities/forking/)
 

--- a/README.MD
+++ b/README.MD
@@ -2,7 +2,7 @@
 
 > ***Comment collaborer à 5000 cerveaux sur la même question ?***
 
-**Un repository GitHub** pour organiser les réflexions sur [l'épisode 3 de **Lets Play Science**](https://youtu.be/noADnHKyRmc?list=PLl5zW0Z-tqm4FoZo7b0V2Rrysh3xuEAZv&t=22m06s) !
+**Un [dépôt](THE_APP.MD#I.7.a) GitHub** pour organiser les réflexions sur [l'épisode 3 de **Lets Play Science**](https://youtu.be/noADnHKyRmc?list=PLl5zW0Z-tqm4FoZo7b0V2Rrysh3xuEAZv&t=22m06s) !
 
 ## Cette plateforme est utilisée comme...
 
@@ -20,7 +20,7 @@
 
 On sera heureux de vous familiariser avec ces outils ;)
 
-## Les objectifs de ce repo ?
+## Les objectifs de ce [dépôt](THE_APP.MD#I.7.a) ?
 
 1. Faire la synthèse des propositions sur youtube  
 [c'est ici : SYNTHESE.MD](SYNTHESE.MD)

--- a/THE_APP.MD
+++ b/THE_APP.MD
@@ -69,6 +69,8 @@ Sommaire
       - a [Application Souveraine](#I.6.a)
       - b [Application Intégrée](#I.6.b)
 
+    7. [Technique](#I.7)
+      - a [Dépôt](#I.7.a)
 
 - II. [Visions d'ensemble (VE)](#II)
   1. [Critères de soumission d'une VE](#II.1)
@@ -327,6 +329,21 @@ On pourrait aussi imaginer une syntaxe pour que l'application « filtre » les m
 **Inconvénients**
 - Authentification par YouTube ou Google+, c'est un parti pris
 - Versionnement des posts rendu plus compliqué
+
+
+<a name="I.7"></a>
+### 7. Technique
+*Définitions d'ordre purement technique*
+
+<a name="I.7.a"></a>
+#### a. Dépôt
+
+Ensemble de fichiers constituant le code source (+ documentations, éléments graphiques...) d'un projet, généralement accessible via un service de gestion de source (git, SVN, etc.).
+
+Sur ce site ([GitHub.com](https://github.com)), les **dépôts** sont également associés à diverses fonctionnalités complémentaires telles qu'un gestionnaire de bugs (issues), détourné en **forum** pour le cas de notre **dépôt lets-play-science**.
+
+Un **dépôt** est également appelé couramment **repository** ou **repo**.
+
 
 <a name="II"></a>
 II. Visions d'ensemble (VE)


### PR DESCRIPTION
Je commence par créer une définition pour "dépôt" puis je modifie les fichiers où le terme "repo" est présent en faisant un lien vers la définition